### PR TITLE
Enable clock synchronization with federates

### DIFF
--- a/rust/rti/src/federate_info.rs
+++ b/rust/rti/src/federate_info.rs
@@ -31,7 +31,7 @@ pub struct FederateInfo {
     // a federate when handling lf_request_stop().
     // TODO: lf_thread_t thread_id;
     stream: Option<TcpStream>, // The TCP socket descriptor for communicating with this federate.
-    // TODO: struct sockaddr_in UDP_addr;
+    udp_addr: SocketAddr,
     clock_synchronization_enabled: bool, // Indicates the status of clock synchronization
     // for this federate. Enabled by default.
     in_transit_message_tags: InTransitMessageQueue, // Record of in-transit messages to this federate that are not
@@ -54,6 +54,7 @@ impl FederateInfo {
             enclave: SchedulingNode::new(),
             requested_stop: false,
             stream: None::<TcpStream>,
+            udp_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
             clock_synchronization_enabled: true,
             in_transit_message_tags: InTransitMessageQueue::new(),
             server_hostname: String::from("localhost"),
@@ -76,6 +77,14 @@ impl FederateInfo {
 
     pub fn stream(&self) -> &Option<TcpStream> {
         &self.stream
+    }
+
+    pub fn stream_mut(&mut self) -> &mut Option<TcpStream> {
+        &mut self.stream
+    }
+
+    pub fn udp_addr(&self) -> SocketAddr {
+        self.udp_addr.clone()
     }
 
     pub fn clock_synchronization_enabled(&self) -> bool {
@@ -108,6 +117,10 @@ impl FederateInfo {
 
     pub fn set_stream(&mut self, stream: TcpStream) {
         self.stream = Some(stream);
+    }
+
+    pub fn set_udp_addr(&mut self, udp_addr: SocketAddr) {
+        self.udp_addr = udp_addr;
     }
 
     pub fn set_clock_synchronization_enabled(&mut self, clock_synchronization_enabled: bool) {

--- a/rust/rti/src/net_common.rs
+++ b/rust/rti/src/net_common.rs
@@ -103,6 +103,10 @@ pub enum MsgType {
     AddressAdvertisement,
     P2pSendingFedId,
     P2pTaggedMessage,
+    ClockSyncT1,
+    ClockSyncT3,
+    ClockSyncT4,
+    ClockSyncCodedProbe,
     PortAbsent,
     NeighborStructure,
     Ignore,
@@ -129,6 +133,10 @@ impl MsgType {
             MsgType::AddressAdvertisement => 14,
             MsgType::P2pSendingFedId => 15,
             MsgType::P2pTaggedMessage => 17,
+            MsgType::ClockSyncT1 => 19,
+            MsgType::ClockSyncT3 => 20,
+            MsgType::ClockSyncT4 => 21,
+            MsgType::ClockSyncCodedProbe => 22,
             MsgType::PortAbsent => 23,
             MsgType::NeighborStructure => 24,
             MsgType::Ignore => 250,
@@ -150,6 +158,10 @@ impl MsgType {
             12 => MsgType::StopGranted,
             13 => MsgType::AddressQuery,
             14 => MsgType::AddressAdvertisement,
+            19 => MsgType::ClockSyncT1,
+            20 => MsgType::ClockSyncT3,
+            21 => MsgType::ClockSyncT4,
+            22 => MsgType::ClockSyncCodedProbe,
             23 => MsgType::PortAbsent,
             _ => MsgType::Ignore,
         }
@@ -181,6 +193,12 @@ impl ErrType {
             ErrType::WrongServer => 5,
         }
     }
+}
+
+#[derive(PartialEq, Clone)]
+pub enum SocketType {
+    TCP,
+    UDP,
 }
 
 #[cfg(test)]

--- a/rust/rti/src/net_util.rs
+++ b/rust/rti/src/net_util.rs
@@ -31,7 +31,7 @@ impl NetUtil {
         } {}
     }
 
-    pub fn read_from_stream(stream: &mut TcpStream, buffer: &mut Vec<u8>, fed_id: u16) -> usize {
+    pub fn read_from_socket(stream: &mut TcpStream, buffer: &mut Vec<u8>, fed_id: u16) -> usize {
         let mut bytes_read = 0;
         while match stream.read(buffer) {
             Ok(msg_size) => {
@@ -209,7 +209,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_from_stream_positive() {
+    fn test_read_from_socket_positive() {
         let port_num = 35642;
         let tcp_server_mocker = TcpServerMocker::new(port_num).unwrap();
         let mut ip_address = LOCAL_HOST.to_owned();
@@ -225,7 +225,7 @@ mod tests {
             ),
         );
         let mut buffer = vec![0 as u8; buffer_size];
-        let read_size = NetUtil::read_from_stream(&mut stream, &mut buffer, 0);
+        let read_size = NetUtil::read_from_socket(&mut stream, &mut buffer, 0);
         assert!(buffer == msg);
         assert!(buffer_size == read_size);
     }

--- a/rust/rti/src/rti_remote.rs
+++ b/rust/rti/src/rti_remote.rs
@@ -16,6 +16,8 @@ use crate::constants::*;
 use crate::ClockSyncStat;
 use crate::RTICommon;
 
+use std::net::UdpSocket;
+
 /**
  * Structure that an RTI instance uses to keep track of its own and its
  * corresponding federates' state.
@@ -61,7 +63,7 @@ pub struct RTIRemote {
     final_port_udp: u16,
 
     /** The UDP socket descriptor for the socket server. */
-    socket_descriptor_udp: i32,
+    socket_descriptor_udp: Option<UdpSocket>,
 
     /************* Clock synchronization information *************/
     /* Thread performing PTP clock sync sessions periodically. */
@@ -80,7 +82,7 @@ pub struct RTIRemote {
     /**
      * Number of messages exchanged for each clock sync attempt.
      */
-    clock_sync_exchanges_per_interval: i32,
+    clock_sync_exchanges_per_interval: u32,
 
     /**
      * Boolean indicating that authentication is enabled.
@@ -105,7 +107,7 @@ impl RTIRemote {
             final_port_tcp: 0,
             socket_descriptor_tcp: -1,
             final_port_udp: u16::MAX,
-            socket_descriptor_udp: -1,
+            socket_descriptor_udp: None,
             clock_sync_global_status: ClockSyncStat::ClockSyncInit,
             clock_sync_period_ns: 10 * 1000000,
             clock_sync_exchanges_per_interval: 10,
@@ -138,12 +140,28 @@ impl RTIRemote {
         self.user_specified_port
     }
 
+    pub fn final_port_tcp(&self) -> u16 {
+        self.final_port_tcp
+    }
+
+    pub fn socket_descriptor_udp(&mut self) -> &mut Option<UdpSocket> {
+        &mut self.socket_descriptor_udp
+    }
+
     pub fn final_port_udp(&self) -> u16 {
         self.final_port_udp
     }
 
     pub fn clock_sync_global_status(&self) -> ClockSyncStat {
         self.clock_sync_global_status.clone()
+    }
+
+    pub fn clock_sync_period_ns(&self) -> u64 {
+        self.clock_sync_period_ns
+    }
+
+    pub fn clock_sync_exchanges_per_interval(&self) -> u32 {
+        self.clock_sync_exchanges_per_interval
     }
 
     pub fn stop_in_progress(&self) -> bool {
@@ -165,6 +183,33 @@ impl RTIRemote {
     // set_user_specified_port
     pub fn set_port(&mut self, user_specified_port: u16) {
         self.user_specified_port = user_specified_port;
+    }
+
+    pub fn set_final_port_tcp(&mut self, final_port_tcp: u16) {
+        self.final_port_tcp = final_port_tcp;
+    }
+
+    pub fn set_socket_descriptor_udp(&mut self, socket_descriptor_udp: Option<UdpSocket>) {
+        self.socket_descriptor_udp = socket_descriptor_udp;
+    }
+
+    pub fn set_final_port_udp(&mut self, final_port_udp: u16) {
+        self.final_port_udp = final_port_udp;
+    }
+
+    pub fn set_clock_sync_global_status(&mut self, clock_sync_global_status: ClockSyncStat) {
+        self.clock_sync_global_status = clock_sync_global_status;
+    }
+
+    pub fn set_clock_sync_period_ns(&mut self, clock_sync_period_ns: u64) {
+        self.clock_sync_period_ns = clock_sync_period_ns;
+    }
+
+    pub fn set_clock_sync_exchanges_per_interval(
+        &mut self,
+        clock_sync_exchanges_per_interval: u32,
+    ) {
+        self.clock_sync_exchanges_per_interval = clock_sync_exchanges_per_interval;
     }
 
     pub fn set_stop_in_progress(&mut self, stop_in_progress: bool) {


### PR DESCRIPTION
- The goal of this PR is to pass **ClockSync.lf** test.
- ~~This PR needs to be rebased after https://github.com/lf-lang/rust-rti/pull/46 is merged.~~