### PR TITLE
Fix a negative value acceptance as the number of federates

### DIFF
--- a/rust/rti/run_unit_tests.sh
+++ b/rust/rti/run_unit_tests.sh
@@ -11,6 +11,7 @@
 # 1. grcov <== cargo install grcov
 # 2. llvm-tools-preview <== rustup component add llvm-tools-preview
 
+rm -rf ./target/coverage
 rm -rf cargo-test-*
 
 CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test

--- a/rust/rti/src/lib.rs
+++ b/rust/rti/src/lib.rs
@@ -71,7 +71,7 @@ pub fn process_args(rti: &mut RTIRemote, argv: &[String]) -> Result<(), &'static
             let num_federates: i64;
             match argv[idx].parse::<i64>() {
                 Ok(parsed_value) => {
-                    if parsed_value == 0 || parsed_value == i64::MAX || parsed_value == i64::MIN {
+                    if parsed_value <= 0 || parsed_value == i64::MAX || parsed_value == i64::MIN {
                         println!("--number_of_federates needs a valid positive integer argument.");
                         usage(argc, argv);
                         return Err("Fail to handle number_of_federates option");
@@ -134,11 +134,6 @@ pub fn process_args(rti: &mut RTIRemote, argv: &[String]) -> Result<(), &'static
             return Err("Invalid argument");
         }
         idx += 1;
-    }
-    if rti.base().number_of_scheduling_nodes() == 0 {
-        println!("--number_of_federates needs a valid positive integer argument.");
-        usage(argc, argv);
-        return Err("Invalid number of enclaves");
     }
     Ok(())
 }
@@ -333,6 +328,16 @@ mod tests {
         let mut args: Vec<String> = Vec::new();
         args.push(String::from("target/debug/rti"));
         args.push(String::from("-n"));
+        assert!(process_args(&mut rti, &args) == Err("Fail to handle number_of_federates option"));
+    }
+
+    #[test]
+    fn test_process_args_option_n_negative_value_negative() {
+        let mut rti = initialize_rti();
+        let mut args: Vec<String> = Vec::new();
+        args.push(String::from("target/debug/rti"));
+        args.push(String::from("-n"));
+        args.push(String::from("-1"));
         assert!(process_args(&mut rti, &args) == Err("Fail to handle number_of_federates option"));
     }
 


### PR DESCRIPTION
- Negative values should cause error returns.
- Delete unreachable code detected by a negative unit test case.
![image](https://github.com/lf-lang/rust-rti/assets/25318511/29e03c81-902d-4924-baae-dc987fcda553)